### PR TITLE
GUID finding + setting util

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,9 +21,7 @@ Sony requires some non-standard packets to display the 'Sending...' on the camer
 
 LINKING THE CAMERA AND THE PTP-GUID:
 -----------------------------------------------------------------
-In order to use this method you do still need to initially install Playmemories on a PC/MAC and link the camera to it.  The key is to obtain the PTP-GUID.  I'm not sure at this point the easiest way to obtain this is it doesn't seem to appear in any config files or settings menus that I can find.  I did find a partial match to the GUID used on the USB controller in the windows registry.  Basically the last 12 digit on this registry entry matched for me if anyone else want to validate: <br>
-HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Enum\USB\VID_14CD&PID_6D00\5&c1e6cce&0&1 <br>
-ContainerID = {a4d7a2f7-c5ae-11e4-93ac-080027f5164f}
+In order to use this method you do still need to initially install Playmemories on a PC/MAC and link the camera to it.  The key is to obtain the PTP-GUID.  PM for Windows uses the MAC addresses of the available interfaces. List them with <code>ipconfig /all</code> on the command line and try them one-by-one.
 
 Otherwise the for-sure method is to run tcpdump/wireshark and watch for the first ptp packet (port 15740).  You will see something like this: <br>
 ```

--- a/README.md
+++ b/README.md
@@ -23,7 +23,9 @@ LINKING THE CAMERA AND THE PTP-GUID:
 -----------------------------------------------------------------
 In order to use this method you do still need to initially install Playmemories on a PC/MAC and link the camera to it.  The key is to obtain the PTP-GUID.  PM for Windows uses the MAC addresses of the available interfaces. List them with <code>ipconfig /all</code> on the command line and try them one-by-one.
 
-Otherwise the for-sure method is to run tcpdump/wireshark and watch for the first ptp packet (port 15740).  You will see something like this: <br>
+Alternatively, you can use sony-guid-setter.c to set the GUIDs from Linux. It's a one-shot tool that will set your camera's authorized GUID defined in its source. Compile it against libusb with <code>gcc -lusb-1.0 sony-guid-setter.c -o sony-guid-setter</code> and run it as <code>sony-guid-setter -g VID:PID</code>. You can find your camera's VID:PID by running lsusb. Most likely, you would want to run this as a user and not as root. "chown" the USB device under /dev/bus/usb/xxx/yyy to your user, if the utility fails with a permission error.
+
+Otherwise the for-sure method is to run tcpdump/wireshark after you used PM on Windows/Mac and watch for the first ptp packet (port 15740).  You will see something like this: <br>
 ```
 00000000  2c 00 00 00 01 00 00 00  00 00 00 00 00 00 00 00 ,....... ........
 00000010  ff ff 08 00 27 f5 16 4f  57 00 49 00 4e 00 37 00 ....'..O W.I.N.7.

--- a/sony-guid-setter.c
+++ b/sony-guid-setter.c
@@ -1,0 +1,536 @@
+/*
+ * sony-guid-setter: Sets authorized PTP/IP GUIDs via USB for some Sony cameras
+ *
+ * This program is heavily derived from xusb.c:
+ * Copyright © 2009-2012 Pete Batard <pete@akeo.ie>
+ * Contributions to Mass Storage by Alan Stern.
+ *
+ * Sony GUID setting protocol reverse engineering:
+ * Copyright 2016 Clemens Fruhwirth <clemens@endorphin.org>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+#include <stdio.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdarg.h>
+
+#include "libusb-1.0/libusb.h"
+
+#if defined(_WIN32)
+#define msleep(msecs) Sleep(msecs)
+#else
+#include <unistd.h>
+#define msleep(msecs) usleep(1000*msecs)
+#endif
+
+#if defined(_MSC_VER)
+#define snprintf _snprintf
+#define putenv _putenv
+#endif
+
+#if !defined(bool)
+#define bool int
+#endif
+#if !defined(true)
+#define true (1 == 1)
+#endif
+#if !defined(false)
+#define false (!true)
+#endif
+
+// Future versions of libusb will use usb_interface instead of interface
+// in libusb_config_descriptor => catter for that
+#define usb_interface interface
+
+static int perr(char const *format, ...)
+{
+	va_list args;
+	int r;
+
+	va_start (args, format);
+	r = vfprintf(stderr, format, args);
+	va_end(args);
+
+	return r;
+}
+
+#define ERR_EXIT(errcode) do { perr("   %s\n", libusb_strerror((enum libusb_error)errcode)); return -1; } while (0)
+#define CALL_CHECK(fcall) do { r=fcall; if (r < 0) ERR_EXIT(r); } while (0);
+#define B(x) (((x)!=0)?1:0)
+#define be_to_int32(buf) (((buf)[0]<<24)|((buf)[1]<<16)|((buf)[2]<<8)|(buf)[3])
+
+#define RETRY_MAX                     5
+#define REQUEST_SENSE_LENGTH          0x12
+
+// Mass Storage Requests values. See section 3 of the Bulk-Only Mass Storage Class specifications
+#define BOMS_RESET                    0xFF
+#define BOMS_GET_MAX_LUN              0xFE
+
+// Section 5.1: Command Block Wrapper (CBW)
+struct command_block_wrapper {
+	uint8_t dCBWSignature[4];
+	uint32_t dCBWTag;
+	uint32_t dCBWDataTransferLength;
+	uint8_t bmCBWFlags;
+	uint8_t bCBWLUN;
+	uint8_t bCBWCBLength;
+	uint8_t CBWCB[16];
+};
+
+// Section 5.2: Command Status Wrapper (CSW)
+struct command_status_wrapper {
+	uint8_t dCSWSignature[4];
+	uint32_t dCSWTag;
+	uint32_t dCSWDataResidue;
+	uint8_t bCSWStatus;
+};
+
+static uint8_t cdb_length[256] = {
+//	 0  1  2  3  4  5  6  7  8  9  A  B  C  D  E  F
+	06,06,06,06,06,06,06,06,06,06,06,06,06,06,06,06,  //  0
+	06,06,06,06,06,06,06,06,06,06,06,06,06,06,06,06,  //  1
+	10,10,10,10,10,10,10,10,10,10,10,10,10,10,10,10,  //  2
+	10,10,10,10,10,10,10,10,10,10,10,10,10,10,10,10,  //  3
+	10,10,10,10,10,10,10,10,10,10,10,10,10,10,10,10,  //  4
+	10,10,10,10,10,10,10,10,10,10,10,10,10,10,10,10,  //  5
+	00,00,00,00,00,00,00,00,00,00,00,00,00,00,00,00,  //  6
+	00,00,00,00,00,00,00,00,00,00,00,00,00,00,00,00,  //  7
+	16,16,16,16,16,16,16,16,16,16,16,16,16,16,16,16,  //  8
+	16,16,16,16,16,16,16,16,16,16,16,16,16,16,16,16,  //  9
+	12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,  //  A
+	12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,  //  B
+	00,00,00,00,00,00,00,00,00,00,00,00,00,00,00,00,  //  C
+	00,00,00,00,00,00,00,00,00,00,00,00,00,00,00,00,  //  D
+	00,00,00,00,00,00,00,00,00,00,00,00,00,00,00,00,  //  E
+	00,00,00,00,00,00,00,00,00,00,00,00,00,00,00,00,  //  F
+};
+
+static enum test_type {
+	USE_GENERIC,
+	USE_SONY_GUID_SETTER,
+} test_mode;
+static uint16_t VID, PID;
+
+static int send_mass_storage_command(libusb_device_handle *handle, uint8_t endpoint, uint8_t lun,
+	uint8_t *cdb, uint8_t direction, int data_length, uint32_t *ret_tag)
+{
+	static uint32_t tag = 1;
+	uint8_t cdb_len;
+	int i, r, size;
+	struct command_block_wrapper cbw;
+
+	if (cdb == NULL) {
+		return -1;
+	}
+
+	if (endpoint & LIBUSB_ENDPOINT_IN) {
+		perr("send_mass_storage_command: cannot send command on IN endpoint\n");
+		return -1;
+	}
+
+	cdb_len = cdb_length[cdb[0]];
+	if ((cdb_len == 0) || (cdb_len > sizeof(cbw.CBWCB))) {
+		perr("send_mass_storage_command: don't know how to handle this command (%02X, length %d)\n",
+			cdb[0], cdb_len);
+		return -1;
+	}
+
+	memset(&cbw, 0, sizeof(cbw));
+	cbw.dCBWSignature[0] = 'U';
+	cbw.dCBWSignature[1] = 'S';
+	cbw.dCBWSignature[2] = 'B';
+	cbw.dCBWSignature[3] = 'C';
+	*ret_tag = tag;
+	cbw.dCBWTag = tag++;
+	cbw.dCBWDataTransferLength = data_length;
+	cbw.bmCBWFlags = direction;
+	cbw.bCBWLUN = lun;
+	// Subclass is 1 or 6 => cdb_len
+	cbw.bCBWCBLength = cdb_len;
+	memcpy(cbw.CBWCB, cdb, cdb_len);
+
+	i = 0;
+	do {
+		// The transfer length must always be exactly 31 bytes.
+		r = libusb_bulk_transfer(handle, endpoint, (unsigned char*)&cbw, 31, &size, 1000);
+		if (r == LIBUSB_ERROR_PIPE) {
+			libusb_clear_halt(handle, endpoint);
+		}
+		i++;
+	} while ((r == LIBUSB_ERROR_PIPE) && (i<RETRY_MAX));
+	if (r != LIBUSB_SUCCESS) {
+		perr("   send_mass_storage_command: %s\n", libusb_strerror((enum libusb_error)r));
+		return -1;
+	}
+
+	printf("   sent %d CDB bytes\n", cdb_len);
+	return 0;
+}
+
+static int get_mass_storage_status(libusb_device_handle *handle, uint8_t endpoint, uint32_t expected_tag)
+{
+	int i, r, size;
+	struct command_status_wrapper csw;
+
+	// The device is allowed to STALL this transfer. If it does, you have to
+	// clear the stall and try again.
+	i = 0;
+	do {
+		r = libusb_bulk_transfer(handle, endpoint, (unsigned char*)&csw, 13, &size, 1000);
+		if (r == LIBUSB_ERROR_PIPE) {
+			libusb_clear_halt(handle, endpoint);
+		}
+		i++;
+	} while ((r == LIBUSB_ERROR_PIPE) && (i<RETRY_MAX));
+	if (r != LIBUSB_SUCCESS) {
+		perr("   get_mass_storage_status: %s\n", libusb_strerror((enum libusb_error)r));
+		return -1;
+	}
+	if (size != 13) {
+		perr("   get_mass_storage_status: received %d bytes (expected 13)\n", size);
+		return -1;
+	}
+	if (csw.dCSWTag != expected_tag) {
+		perr("   get_mass_storage_status: mismatched tags (expected %08X, received %08X)\n",
+			expected_tag, csw.dCSWTag);
+		return -1;
+	}
+	// For this test, we ignore the dCSWSignature check for validity...
+	printf("   Mass Storage Status: %02X (%s)\n", csw.bCSWStatus, csw.bCSWStatus?"FAILED":"Success");
+	if (csw.dCSWTag != expected_tag)
+		return -1;
+	if (csw.bCSWStatus) {
+		// REQUEST SENSE is appropriate only if bCSWStatus is 1, meaning that the
+		// command failed somehow.  Larger values (2 in particular) mean that
+		// the command couldn't be understood.
+		if (csw.bCSWStatus == 1)
+			return -2;	// request Get Sense
+		else
+			return -1;
+	}
+
+	// In theory we also should check dCSWDataResidue.  But lots of devices
+	// set it wrongly.
+	return 0;
+}
+
+static void get_sense(libusb_device_handle *handle, uint8_t endpoint_in, uint8_t endpoint_out)
+{
+	uint8_t cdb[16];	// SCSI Command Descriptor Block
+	uint8_t sense[18];
+	uint32_t expected_tag;
+	int size;
+	int rc;
+
+	// Request Sense
+	printf("Request Sense:\n");
+	memset(sense, 0, sizeof(sense));
+	memset(cdb, 0, sizeof(cdb));
+	cdb[0] = 0x03;	// Request Sense
+	cdb[4] = REQUEST_SENSE_LENGTH;
+
+	send_mass_storage_command(handle, endpoint_out, 0, cdb, LIBUSB_ENDPOINT_IN, REQUEST_SENSE_LENGTH, &expected_tag);
+	rc = libusb_bulk_transfer(handle, endpoint_in, (unsigned char*)&sense, REQUEST_SENSE_LENGTH, &size, 1000);
+	if (rc < 0)
+	{
+		printf("libusb_bulk_transfer failed: %s\n", libusb_error_name(rc));
+		return;
+	}
+	printf("   received %d bytes\n", size);
+
+	if ((sense[0] != 0x70) && (sense[0] != 0x71)) {
+		perr("   ERROR No sense data\n");
+	} else {
+		perr("   ERROR Sense: %02X %02X %02X\n", sense[2]&0x0F, sense[12], sense[13]);
+	}
+	// Strictly speaking, the get_mass_storage_status() call should come
+	// before these perr() lines.  If the status is nonzero then we must
+	// assume there's no data in the buffer.  For xusb it doesn't matter.
+	get_mass_storage_status(handle, endpoint_in, expected_tag);
+}
+
+
+// SONY GUID SETTING:
+// 1. Emit a non-standard CDB (command=0x7a, len=9), see set_guid_cdb array above.
+// 2. Bulk-write a 8192 byte, as per the set_guid_bulk struct
+// 3. Read back the command status, probably optional.
+unsigned char set_guid_cdb[] = {
+  0x7a, 0x04, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+};
+
+struct set_guid_bulk {
+  #define SET_GUID_BULK_MAGIC1 { 0x25, 0x01, 0x00, 0x00, 0x08 }
+  uint8_t magic1[5]; // Must be initialized as above
+  uint8_t zeros1[12];
+  uint8_t name[16]; // looks like UTF-16LE of the hostname
+  uint8_t zeros2[9*16];
+  #define SET_GUID_BULK_MAGIC2 { 0x10, 0x00, 0x00, 0x00 }
+  uint8_t magic2[4]; // Must be initialized as above
+  uint8_t guid1[8];
+  uint8_t guid2[8];
+  uint8_t zeros3[7995];
+};
+
+// Mass Storage device to test bulk transfers (non destructive test)
+static int sony_guid_setter(libusb_device_handle *handle, uint8_t endpoint_in, uint8_t endpoint_out)
+{
+	int r, size;
+	uint8_t lun;
+	uint32_t expected_tag;
+
+	struct set_guid_bulk cmd = {
+	  .magic1 = SET_GUID_BULK_MAGIC1,
+	  .magic2 = SET_GUID_BULK_MAGIC2,
+	  // Some random GUIDs. Change them if they make you feel insecure
+	  .guid1 = { 0xff, 0xff, 0x52, 0x54, 0x00, 0xb6, 0xfd, 0xa9 },
+	  .guid2 = { 0xff, 0xff, 0x52, 0x3c, 0x28, 0x07, 0xa9, 0x3a },
+	  // On the first PTP/IP connect, the camera changes its
+	  // stored hostname to the hostname in the PTP/IP. Don't
+	  // bother changing that here.
+	  .name = { 'l', 0, 'i', 0, 'n', 0, 'u', 0, 'x', 0} };
+
+	printf("Reading Max LUN:\n");
+	r = libusb_control_transfer(handle, LIBUSB_ENDPOINT_IN|LIBUSB_REQUEST_TYPE_CLASS|LIBUSB_RECIPIENT_INTERFACE,
+		BOMS_GET_MAX_LUN, 0, 0, &lun, 1, 1000);
+	// Some devices send a STALL instead of the actual value.
+	// In such cases we should set lun to 0.
+	if (r == 0) {
+		lun = 0;
+	} else if (r < 0) {
+		perr("   Failed: %s", libusb_strerror((enum libusb_error)r));
+	}
+	printf("   Max LUN = %d\n", lun);
+
+	// Patch up cdb_length table for non-standard 0x7a CMD. Do
+	// that here, so the changes to the original xusb.c code are
+	// not too far spread out.
+	cdb_length[set_guid_cdb[0]] = sizeof(set_guid_cdb);
+
+	// Send non-standard CDB
+	send_mass_storage_command(handle, endpoint_out, lun, set_guid_cdb, LIBUSB_ENDPOINT_OUT, sizeof(cmd), &expected_tag);
+
+	// Send bulk
+	CALL_CHECK(libusb_bulk_transfer(handle, endpoint_out, (char *)&cmd, sizeof(cmd), &size, 1000));
+	printf("   sent %d bytes\n", size);
+
+	// Read status
+	if (get_mass_storage_status(handle, endpoint_in, expected_tag) == -2) {
+		get_sense(handle, endpoint_in, endpoint_out);
+	}
+	return 0;
+}
+
+static int test_device(uint16_t vid, uint16_t pid)
+{
+	libusb_device_handle *handle;
+	libusb_device *dev;
+	struct libusb_config_descriptor *conf_desc;
+	const struct libusb_endpoint_descriptor *endpoint;
+	int i, j, k, r;
+	int iface, nb_ifaces, first_iface = -1;
+	uint8_t endpoint_in = 0, endpoint_out = 0;	// default IN and OUT endpoints
+
+	printf("Opening device %04X:%04X...\n", vid, pid);
+	handle = libusb_open_device_with_vid_pid(NULL, vid, pid);
+
+	if (handle == NULL) {
+		perr("  Failed.\n");
+		return -1;
+	}
+
+	dev = libusb_get_device(handle);
+
+	printf("\nReading first configuration descriptor:\n");
+	CALL_CHECK(libusb_get_config_descriptor(dev, 0, &conf_desc));
+	nb_ifaces = conf_desc->bNumInterfaces;
+	printf("             nb interfaces: %d\n", nb_ifaces);
+	if (nb_ifaces > 0)
+		first_iface = conf_desc->usb_interface[0].altsetting[0].bInterfaceNumber;
+	for (i=0; i<nb_ifaces; i++) {
+		printf("              interface[%d]: id = %d\n", i,
+			conf_desc->usb_interface[i].altsetting[0].bInterfaceNumber);
+		for (j=0; j<conf_desc->usb_interface[i].num_altsetting; j++) {
+			printf("interface[%d].altsetting[%d]: num endpoints = %d\n",
+				i, j, conf_desc->usb_interface[i].altsetting[j].bNumEndpoints);
+			printf("   Class.SubClass.Protocol: %02X.%02X.%02X\n",
+				conf_desc->usb_interface[i].altsetting[j].bInterfaceClass,
+				conf_desc->usb_interface[i].altsetting[j].bInterfaceSubClass,
+				conf_desc->usb_interface[i].altsetting[j].bInterfaceProtocol);
+			for (k=0; k<conf_desc->usb_interface[i].altsetting[j].bNumEndpoints; k++) {
+				struct libusb_ss_endpoint_companion_descriptor *ep_comp = NULL;
+				endpoint = &conf_desc->usb_interface[i].altsetting[j].endpoint[k];
+				printf("       endpoint[%d].address: %02X\n", k, endpoint->bEndpointAddress);
+				// Use the first interrupt or bulk IN/OUT endpoints as default for testing
+				if ((endpoint->bmAttributes & LIBUSB_TRANSFER_TYPE_MASK) & (LIBUSB_TRANSFER_TYPE_BULK | LIBUSB_TRANSFER_TYPE_INTERRUPT)) {
+					if (endpoint->bEndpointAddress & LIBUSB_ENDPOINT_IN) {
+						if (!endpoint_in)
+							endpoint_in = endpoint->bEndpointAddress;
+					} else {
+						if (!endpoint_out)
+							endpoint_out = endpoint->bEndpointAddress;
+					}
+				}
+				printf("           max packet size: %04X\n", endpoint->wMaxPacketSize);
+				printf("          polling interval: %02X\n", endpoint->bInterval);
+				libusb_get_ss_endpoint_companion_descriptor(NULL, endpoint, &ep_comp);
+				if (ep_comp) {
+					printf("                 max burst: %02X   (USB 3.0)\n", ep_comp->bMaxBurst);
+					printf("        bytes per interval: %04X (USB 3.0)\n", ep_comp->wBytesPerInterval);
+					libusb_free_ss_endpoint_companion_descriptor(ep_comp);
+				}
+			}
+		}
+	}
+	libusb_free_config_descriptor(conf_desc);
+
+	libusb_set_auto_detach_kernel_driver(handle, 1);
+	for (iface = 0; iface < nb_ifaces; iface++)
+	{
+		printf("\nClaiming interface %d...\n", iface);
+		r = libusb_claim_interface(handle, iface);
+		if (r != LIBUSB_SUCCESS) {
+			perr("   Failed.\n");
+		}
+	}
+
+	switch(test_mode) {
+	case USE_SONY_GUID_SETTER:
+		CALL_CHECK(sony_guid_setter(handle, endpoint_in, endpoint_out));
+	case USE_GENERIC:
+		break;
+	}
+
+	printf("\n");
+	for (iface = 0; iface<nb_ifaces; iface++) {
+		printf("Releasing interface %d...\n", iface);
+		libusb_release_interface(handle, iface);
+	}
+
+	printf("Closing device...\n");
+	libusb_close(handle);
+
+	return 0;
+}
+
+int main(int argc, char** argv)
+{
+	bool show_help = false;
+	bool debug_mode = false;
+	const struct libusb_version* version;
+	int j, r;
+	size_t i, arglen;
+	unsigned tmp_vid, tmp_pid;
+	uint16_t endian_test = 0xBE00;
+	char *error_lang = NULL, *old_dbg_str = NULL, str[256];
+
+	// Default to generic, expecting VID:PID
+	VID = 0;
+	PID = 0;
+	test_mode = USE_GENERIC;
+
+	if (((uint8_t*)&endian_test)[0] == 0xBE) {
+		printf("Despite their natural superiority for end users, big endian\n"
+			"CPUs are not supported with this program, sorry.\n");
+		return 0;
+	}
+
+	if (argc >= 2) {
+		for (j = 1; j<argc; j++) {
+			arglen = strlen(argv[j]);
+			if ( ((argv[j][0] == '-') || (argv[j][0] == '/'))
+			  && (arglen >= 2) ) {
+				switch(argv[j][1]) {
+				case 'd':
+					debug_mode = true;
+					break;
+				case 'l':
+					if ((j+1 >= argc) || (argv[j+1][0] == '-') || (argv[j+1][0] == '/')) {
+						printf("   Option -l requires an ISO 639-1 language parameter\n");
+						return 1;
+					}
+					error_lang = argv[++j];
+					break;
+				case 'g':
+					test_mode = USE_SONY_GUID_SETTER;
+					break;
+				default:
+					show_help = true;
+					break;
+				}
+			} else {
+				for (i=0; i<arglen; i++) {
+					if (argv[j][i] == ':')
+						break;
+				}
+				if (i != arglen) {
+					if (sscanf(argv[j], "%x:%x" , &tmp_vid, &tmp_pid) != 2) {
+						printf("   Please specify VID & PID as \"vid:pid\" in hexadecimal format\n");
+						return 1;
+					}
+					VID = (uint16_t)tmp_vid;
+					PID = (uint16_t)tmp_pid;
+				} else {
+					show_help = true;
+				}
+			}
+		}
+	}
+
+	if ((show_help) || (argc == 1) || (argc > 7)) {
+		printf("usage: %s [-h] [-d] [-i] [-k] [-b file] [-l lang] [-j] [-x] [-s] [-p] [-w] [vid:pid]\n", argv[0]);
+		printf("   -h      : display usage\n");
+		printf("   -d      : enable debug output\n");
+		printf("   -g      : Sony Set GUID\n");
+		printf("   -l lang : language to report errors in (ISO 639-1)\n");
+		return 0;
+	}
+
+	// xusb is commonly used as a debug tool, so it's convenient to have debug output during libusb_init(),
+	// but since we can't call on libusb_set_debug() before libusb_init(), we use the env variable method
+	old_dbg_str = getenv("LIBUSB_DEBUG");
+	if (debug_mode) {
+		if (putenv("LIBUSB_DEBUG=4") != 0)	// LIBUSB_LOG_LEVEL_DEBUG
+			printf("Unable to set debug level");
+	}
+
+	version = libusb_get_version();
+	printf("Using libusb v%d.%d.%d.%d\n\n", version->major, version->minor, version->micro, version->nano);
+	r = libusb_init(NULL);
+	if (r < 0)
+		return r;
+
+	// If not set externally, and no debug option was given, use info log level
+	if ((old_dbg_str == NULL) && (!debug_mode))
+		libusb_set_debug(NULL, LIBUSB_LOG_LEVEL_INFO);
+	if (error_lang != NULL) {
+		r = libusb_setlocale(error_lang);
+		if (r < 0)
+			printf("Invalid or unsupported locale '%s': %s\n", error_lang, libusb_strerror((enum libusb_error)r));
+	}
+
+	test_device(VID, PID);
+
+	libusb_exit(NULL);
+
+	if (debug_mode) {
+		snprintf(str, sizeof(str), "LIBUSB_DEBUG=%s", (old_dbg_str == NULL)?"":old_dbg_str);
+		str[sizeof(str) - 1] = 0;	// Windows may not NUL terminate the string
+	}
+
+	return 0;
+}


### PR DESCRIPTION
I reverse engineered the USB GUID setting protocol, and at the end didn't have to as I also found out that it's just the MAC addresses that PM Win sees locally.

sony-guid-setter.c is heavily derived from xusb.c, and not particularly polished, given that's a one-shot tool. I hope that helps people.