### PR TITLE
Update Dockerfile to python 3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:2-alpine3.9
+FROM python:3-alpine3.9
 
 RUN apk add --no-cache gphoto2
 RUN pip install --no-cache requests


### PR DESCRIPTION
Got the following error with python 2:
```
Traceback (most recent call last):
  File "sony-pm-alt.py", line 2, in <module>
    import socket, struct, time, socketserver, re, subprocess, sys, logging, logging.handlers
ImportError: No module named socketserver
```
Script seems to work with python 3.